### PR TITLE
Extend client classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,20 @@ Or install it yourself as:
 
 ## Usage
 ```ruby
-class Example
+class YourClass
   include Greenjaguar
 
-  def initialize
-    @policy = PolicyBuilder.new do
-      retry_times 10
-      with_strategy :exponential_backoff
-      measure_time_in :ms
-      only_on_exceptions [Net::HTTPError]
+  def your_method
+    # Build retrying policies
+    @policy = build_policy do
+        retry_times 10
+        with_strategy :exponential_backoff
+        measure_time_in :ms
+        only_on_exceptions [Net::HTTPError]
     end
-  end
 
-  def some_method
-    Retrier.run(@policy) do
+    # Executes your code using the policy
+    robust_retry(@policy) do
       # Your code goes here
     end
   end

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class YourClass
   include Greenjaguar
 
   def your_method
-    # Build retrying policies
+    # Build retry policy
     @policy = build_policy do
         retry_times 10
         with_strategy :exponential_backoff

--- a/greenjaguar.gemspec
+++ b/greenjaguar.gemspec
@@ -25,5 +25,5 @@ exponential backoff, FixedInterval, etc. This basically is the 'retry' construct
   spec.add_development_dependency "guard-rspec", "~> 4.6"
   spec.add_development_dependency "byebug", "~> 6.0"
   spec.add_development_dependency "webmock", "~> 1.21"
-  spec.add_development_dependency "minitest", "~> 0"
+  spec.add_development_dependency "minitest"
 end

--- a/greenjaguar.gemspec
+++ b/greenjaguar.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["anides84 AT hotmail DOT com"]
   spec.summary       = %q{Applies retry behavior to arbitrary code blocks with different policies like fibonacci,
 exponential backoff, FixedInterval, etc. This basically is the 'retry' construct on steroids.}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/aniruddha84/greenjaguar"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
@@ -20,14 +20,10 @@ exponential backoff, FixedInterval, etc. This basically is the 'retry' construct
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rspec-nc"
-  spec.add_development_dependency "guard"
-  spec.add_development_dependency "guard-rspec"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "pry-remote"
-  spec.add_development_dependency "pry-nav"
-  spec.add_development_dependency "byebug"
-  spec.add_development_dependency "webmock"
-  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "guard", "~> 2.12"
+  spec.add_development_dependency "guard-rspec", "~> 4.6"
+  spec.add_development_dependency "byebug", "~> 6.0"
+  spec.add_development_dependency "webmock", "~> 1.21"
+  spec.add_development_dependency "minitest", "~> 0"
 end

--- a/lib/greenjaguar.rb
+++ b/lib/greenjaguar.rb
@@ -6,3 +6,20 @@ require 'greenjaguar/strategies/exponential_backoff_strategy'
 require 'greenjaguar/strategies/fixed_interval_strategy'
 require 'greenjaguar/policy_builder'
 require 'greenjaguar/retrier'
+
+module Greenjaguar
+
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def build_policy(&block)
+      PolicyBuilder.new(&block)
+    end
+
+    def robust_retry(policy, &block)
+      Retrier.new(policy, &block)
+    end
+  end
+end

--- a/lib/greenjaguar/retrier.rb
+++ b/lib/greenjaguar/retrier.rb
@@ -1,12 +1,5 @@
 module Greenjaguar
   class Retrier
-    class << self
-      def run(policy, &block)
-        self.new(policy, &block)
-      end
-    end
-
-    private
 
     def initialize(policy, &block)
       @policy = policy
@@ -14,6 +7,7 @@ module Greenjaguar
       exec
     end
 
+    private
     def exec
       @start_time = Time.new
       begin


### PR DESCRIPTION
Contains Major Refactoring that changes the libraries interface. Module will extend client classes to have 2 class methods. This obviates the need for clients to "know" about PolicyBuilder or Retrier classes.
- build_policy
- robust_retry

Also contains changes to the gemspec
- Added url
- Short Description
- Added versions to dev dependencies
